### PR TITLE
Fixed overlay bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@ title: Homepage
 <div class="well whatsallabout row">
   <div class="span4">
     <h3>On TV</h3>
-      <iframe height="230" src="http://www.youtube.com/embed/Je-5_O0j85g" allowfullscreen></iframe>
+      <iframe height="230" src="http://www.youtube.com/embed/Je-5_O0j85g?wmode=opaque" allowfullscreen></iframe>
   </div>
   <div class="span4">
     <h4>&nbsp;</h4>
@@ -68,16 +68,16 @@ title: Homepage
   <div class="span3">
     <h3>What is Coworking?</h3>
     <p>
-      CoWorking is a community endeavor where multiple entrepreneurs, 
-      small business owners, freelancers, and creative professionals 
-      share office space, ideas, visions, dreams, and more. 
+      CoWorking is a community endeavor where multiple entrepreneurs,
+      small business owners, freelancers, and creative professionals
+      share office space, ideas, visions, dreams, and more.
     </p>
     <p>
-      CoWorking is a fresh and innovative way to work that encourages both 
-      creativity and productivity while providing a respite from 
+      CoWorking is a fresh and innovative way to work that encourages both
+      creativity and productivity while providing a respite from
       cluttered home offices, busy cafe’s, and other stressful work spaces.
-      With a minimal financial commitment, your business is empowered 
-      by a connection with other inspiring people.   
+      With a minimal financial commitment, your business is empowered
+      by a connection with other inspiring people.
     </p>
   </div>
 </div>
@@ -164,7 +164,7 @@ title: Homepage
       <div class="modal-body">
 
         <div class="control-group">
-          <label for="entry_0">Name</label> 
+          <label for="entry_0">Name</label>
           <div class="controls">
             <input type="text" name="entry.0.single" id="entry_0" required />
           </div>
@@ -178,14 +178,14 @@ title: Homepage
         </div>
 
         <div class="control-group">
-          <label for="entry_2">Email/Phone/Skype</label> 
+          <label for="entry_2">Email/Phone/Skype</label>
           <div class="controls">
             <input type="text" name="entry.2.single" id="entry_2" required />
           </div>
         </div>
 
         <div class="control-group">
-          <label for="entry_3">Message</label> 
+          <label for="entry_3">Message</label>
           <div class="controls">
             <textarea name="entry.3.single" rows="8" cols="30" id="entry_3" required></textarea>
           </div>


### PR DESCRIPTION
Browser: Google Chrome (any OS)

Reproduce steps: Click on any picture thumbnail. An overlay with the bigger picture opens. Instead of staying below the overlay shadow, the YouTube embed comes on top.

Solution: added ?wmode=opaque to the embed URL.
